### PR TITLE
Revert "tiny bug"

### DIFF
--- a/src/main/java/house/inksoftware/systemtest/domain/steps/response/rest/ExpectedRestResponseStep.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/steps/response/rest/ExpectedRestResponseStep.java
@@ -35,9 +35,9 @@ public class ExpectedRestResponseStep implements ExpectedResponseStep {
         var objectMapper = new ObjectMapper();
         var root = objectMapper.readTree(json);
 
-        int httpCode = JsonPath.parse(json).read("httpCode");
+        var httpCode = root.get("httpCode").asInt();
         var body = root.path("body");
-        var bodyAsJson = JsonPath.parse((Object) JsonPath.parse(json).read("body")).jsonString();
+        var bodyAsJson = JsonPath.parse(json).jsonString();
         var verification = root.path("verification");
 
         Set<String> verificationFieldSet = new HashSet<>();
@@ -60,15 +60,17 @@ public class ExpectedRestResponseStep implements ExpectedResponseStep {
         var objectMapper = new ObjectMapper();
         var actualResponseBody = objectMapper.readTree(response.body());
 
-        compareHttpStatuses(response);
+        compareHttpStatuses(actualResponseBody);
+
+        actualResponseBody = actualResponseBody.path("body");
 
         compareUsingVerification(actualResponseBody);
         compareIfExactSame(actualResponseBody);
 
     }
 
-    private void compareHttpStatuses(ActualResponse response) {
-        assertEquals(httpCode, ((ActualRestResponse) response).getStatusCode());
+    private void compareHttpStatuses(JsonNode actualResponseBody) {
+        assertEquals(httpCode, actualResponseBody.get("httpCode").asInt());
     }
 
     private void compareIfExactSame(JsonNode actualResponseBody) {


### PR DESCRIPTION
Reverts INK-Solutions/system-test-framework#22
 
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates the `ExpectedRestResponseStep` class to directly access HTTP code and body from JSON responses using `JsonNode.get` method, and modifies `assertResponseIsCorrect` method to accept `JsonNode` as an argument for comparison.

**Key Points**

1. Replaces `JsonPath.parse` with `JsonNode.get` for extracting HTTP code and body.
2. Updates `assertResponseIsCorrect` method to accept `JsonNode` and parse body before comparison.
3. Modifies `compareHttpStatuses` method to accept `JsonNode` and compares HTTP codes directly. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>