### PR TITLE
Feature/grpc ci support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'house.inksoftware'
-version 'java-21-0.1.2'
+version 'java-21-0.1.3'
 
 java {
     sourceCompatibility = '21'

--- a/src/main/java/house/inksoftware/systemtest/SystemTest.java
+++ b/src/main/java/house/inksoftware/systemtest/SystemTest.java
@@ -9,6 +9,7 @@ import house.inksoftware.systemtest.domain.config.infra.InfrastructureConfigurat
 import house.inksoftware.systemtest.domain.config.infra.InfrastructureLauncher;
 import house.inksoftware.systemtest.domain.config.infra.SystemTestResourceLauncher;
 import house.inksoftware.systemtest.domain.config.infra.kafka.incoming.KafkaEventProcessedCallback;
+import house.inksoftware.systemtest.domain.config.infra.rest.TestRestTemplateConfig;
 import house.inksoftware.systemtest.domain.context.SystemTestContext;
 import house.inksoftware.systemtest.domain.steps.request.RequestStep;
 import house.inksoftware.systemtest.domain.steps.request.RequestStepFactory;
@@ -17,13 +18,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
@@ -40,6 +41,7 @@ import static org.springframework.test.context.TestExecutionListeners.MergeMode.
 @Slf4j
 @TestExecutionListeners(value = {SystemTest.class}, mergeMode = MERGE_WITH_DEFAULTS)
 @ActiveProfiles("systemtest")
+@Import(TestRestTemplateConfig.class)
 @RequiredArgsConstructor
 @RunWith(SpringRunner.class)
 public class SystemTest implements TestExecutionListener {
@@ -61,16 +63,16 @@ public class SystemTest implements TestExecutionListener {
     @Override
     public void beforeTestClass(TestContext testContext) throws Exception {
         Optional<File> systemTestYaml = findSystemTestYaml();
-        Assert.assertTrue(
+        Assertions.assertTrue(
+                systemTestYaml.isPresent(),
                 "File application-systemtest.yml is not found! " +
-                "Please add it if it's not present or rename existing test yml file to application-systemtest.yml",
-                systemTestYaml.isPresent()
+                "Please add it if it's not present or rename existing test yml file to application-systemtest.yml"
         );
 
         Optional<File> systemTestConfFile = findSystemTestConfig();
-        Assert.assertTrue(
-                "File system-test-configuration.json is not found! Please add it and define your infra requirements.",
-                systemTestConfFile.isPresent()
+        Assertions.assertTrue(
+                systemTestConfFile.isPresent(),
+                "File system-test-configuration.json is not found! Please add it and define your infra requirements."
         );
         LinkedHashMap<String, Object> infrastructure = findInfraConfig(systemTestConfFile.get());
         infrastructureLauncher.launchDb(testContext, infrastructure);

--- a/src/main/java/house/inksoftware/systemtest/domain/config/infra/InfrastructureConfiguration.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/config/infra/InfrastructureConfiguration.java
@@ -40,10 +40,10 @@ public class InfrastructureConfiguration {
                 try {
                     HttpEntity<String> request = new HttpEntity<>(jsonContract);
                     String host;
-                    if (System.getenv("CI").equalsIgnoreCase("true")) {
-                        host = "docker";
-                    } else {
+                    if (System.getenv("TEST_HOST") == null) {
                         host = "localhost";
+                    } else {
+                        host = System.getenv("TEST_HOST");
                     }
                     restTemplate.postForObject("http://" + host + ":4771/add", request, String.class);
                 } catch (Exception e) {

--- a/src/main/java/house/inksoftware/systemtest/domain/config/infra/InfrastructureConfiguration.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/config/infra/InfrastructureConfiguration.java
@@ -39,7 +39,13 @@ public class InfrastructureConfiguration {
                 String jsonContract = objectMapper.writeValueAsString(contract);
                 try {
                     HttpEntity<String> request = new HttpEntity<>(jsonContract);
-                    restTemplate.postForObject("http://localhost:4771/add", request, String.class);
+                    String host;
+                    if (System.getenv("CI").equalsIgnoreCase("true")) {
+                        host = "docker";
+                    } else {
+                        host = "localhost";
+                    }
+                    restTemplate.postForObject("http://" + host + ":4771/add", request, String.class);
                 } catch (Exception e) {
                     log.error(e.getMessage());
                 }

--- a/src/main/java/house/inksoftware/systemtest/domain/config/infra/rest/TestRestTemplateConfig.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/config/infra/rest/TestRestTemplateConfig.java
@@ -1,0 +1,28 @@
+package house.inksoftware.systemtest.domain.config.infra.rest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+
+import java.time.Duration;
+
+@TestConfiguration
+public class TestRestTemplateConfig {
+
+    @Value("${systemtest.testRestTemplate.connection-timeout:10}")
+    private long connectionTimeoutSeconds;
+
+    @Value("${systemtest.testRestTemplate.read-timeout:10}")
+    private long readTimeoutSeconds;
+
+    @Bean
+    public TestRestTemplate testRestTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return new TestRestTemplate(
+                restTemplateBuilder
+                        .setConnectTimeout(Duration.ofSeconds(connectionTimeoutSeconds))
+                        .setReadTimeout(Duration.ofSeconds(readTimeoutSeconds))
+        );
+    }
+}


### PR DESCRIPTION
- Added the option to specify grpc host to call via environment variable TEST_HOST (when running the test on gitlab localhost is not the host that the grpc container runs in)
- Added the option to specify connection and read timeout of testRestTemplate with defaults 10 (we have a use case where we want to control the timeout as the api call is timing out during the test)