### PR TITLE
multiple que names

### DIFF
--- a/src/main/java/house/inksoftware/systemtest/domain/steps/response/sqs/ExpectedSqsResponseStep.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/steps/response/sqs/ExpectedSqsResponseStep.java
@@ -8,30 +8,42 @@ import house.inksoftware.systemtest.domain.steps.response.ActualResponse;
 import house.inksoftware.systemtest.domain.steps.response.ExpectedResponseStep;
 import lombok.Data;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 
 @Data
 public class ExpectedSqsResponseStep implements ExpectedResponseStep {
-    private final String queueName;
-    private final List<String> expectedBodies;
+    private final Map<String, List<String>> queueMessages;
     private final SqsConsumerService sqsConsumerService;
 
     public static ExpectedSqsResponseStep from(String json, SqsConfiguration sqsConfiguration) {
         DocumentContext documentContext = JsonPath.parse(json);
-        var bodies = documentContext.read("body", List.class);
+        Map<String, List<String>> queueMessages = new HashMap<>();
 
-        var parsedBodies = bodies.stream()
-                .map(body -> JsonPath.parse(body).jsonString())
-                .toList();
+        List<Map<String, Object>> queues = documentContext.read("$.queues", List.class);
+
+        for (Map<String, Object> queue : queues) {
+            String queueName = (String) queue.get("name");
+            List<Object> bodies = (List<Object>) queue.get("body");
+
+            var parsedBodies = bodies.stream()
+                    .map(body -> JsonPath.parse(body).jsonString())
+                    .toList();
+
+            queueMessages.put(queueName, parsedBodies);
+        }
 
         return new ExpectedSqsResponseStep(
-                documentContext.read("queue"),
-                parsedBodies,
+                queueMessages,
                 sqsConfiguration.getSqsConsumerService()
         );
     }
+
     @Override
     public void assertResponseIsCorrect(ActualResponse actualResponse) {
-        sqsConsumerService.find(queueName, expectedBodies);
+        queueMessages.forEach(sqsConsumerService::find
+        );
     }
 }


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR enhances the system test framework to support asserting messages on multiple SQS queues within a single test step.  Previously, only one queue could be specified.

**Key Changes**
- Replaces the single `queueName` and `expectedBodies` fields in `ExpectedSqsResponseStep` with a `queueMessages` map, allowing for multiple queue names and their corresponding expected message bodies.
- Updates the `from` method to parse the new JSON structure with multiple queues, populating the `queueMessages` map.
- Modifies the `assertResponseIsCorrect` method to iterate through the `queueMessages` map and call the `find` method for each queue and its expected messages.

**Recommendations**
Ready for merge after unit tests are added to verify the updated parsing and assertion logic for multiple queues.  Consider adding integration tests to validate the functionality in a real-world scenario.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>