### PR TITLE
adding body checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,10 +73,7 @@ publishing {
         mavenLocal()
         maven {
             url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            credentials {
-                username = '95KontyU'
-                password = 'qT07yl78KYf69ccAtwkv0GOWkaZPz5gHAb0681Z6S999'
-            }
+
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'house.inksoftware'
-version 'java-21-0.1.5'
+version 'java-21-0.1.6'
 
 java {
     sourceCompatibility = '21'
@@ -74,8 +74,8 @@ publishing {
         maven {
             url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
             credentials {
-                username = 'ivan.inksoftware'
-                password = System.getenv('MAVEN_REPO_PASSWORD') ?: ''
+                username = '95KontyU'
+                password = 'qT07yl78KYf69ccAtwkv0GOWkaZPz5gHAb0681Z6S999'
             }
         }
     }

--- a/src/main/java/house/inksoftware/systemtest/domain/steps/response/rest/BodyCheck.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/steps/response/rest/BodyCheck.java
@@ -1,0 +1,58 @@
+package house.inksoftware.systemtest.domain.steps.response.rest;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+import java.util.function.BiFunction;
+
+@Data
+@Builder
+public class BodyCheck {
+    private String path;
+    private ComparisonType type;
+    private Object value;
+
+    public boolean validate(Object actualValue) {
+        return type.compare(actualValue, value);
+    }
+
+
+    @Getter
+    public enum ComparisonType {
+        GREATER_THAN("GREATER_THAN") {
+            @Override
+            public boolean compare(Object actual, Object expected) {
+                return compareNumbers(actual, expected, (a, b) -> a > b);
+            }
+        };
+
+        private final String value;
+
+        ComparisonType(String value) {
+            this.value = value;
+        }
+
+        public abstract boolean compare(Object actual, Object expected);
+
+        protected boolean compareNumbers(Object actual, Object expected, BiFunction<Double, Double, Boolean> comparison) {
+            try {
+                Double actualNum = convertToDouble(actual);
+                Double expectedNum = convertToDouble(expected);
+                return comparison.apply(actualNum, expectedNum);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+
+        private Double convertToDouble(Object value) {
+            if (value instanceof Number) {
+                return ((Number) value).doubleValue();
+            }
+            if (value instanceof String) {
+                return Double.parseDouble((String) value);
+            }
+            throw new NumberFormatException("Cannot convert value to number: " + value);
+        }
+    }
+}

--- a/src/main/java/house/inksoftware/systemtest/domain/steps/response/rest/ExpectedRestResponseStep.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/steps/response/rest/ExpectedRestResponseStep.java
@@ -1,6 +1,9 @@
 package house.inksoftware.systemtest.domain.steps.response.rest;
 
+import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.TypeRef;
 import house.inksoftware.systemtest.domain.steps.response.ActualResponse;
 import house.inksoftware.systemtest.domain.steps.response.ExpectedResponseStep;
 import house.inksoftware.systemtest.domain.utils.JsonUtils;
@@ -9,21 +12,70 @@ import lombok.SneakyThrows;
 import org.json.JSONException;
 import org.junit.Assert;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Data
 public class ExpectedRestResponseStep implements ExpectedResponseStep {
     private final int httpCode;
     private final String body;
+    private final List<BodyCheck> bodyChecks;
+
 
     public static ExpectedRestResponseStep from(String json) {
-        int httpCode = JsonPath.parse(json).read("httpCode");
-        String body = JsonPath.parse((Object) JsonPath.parse(json).read("body")).jsonString();
+        DocumentContext context = JsonPath.parse(json);
+        int httpCode = context.read("httpCode");
+        String body = JsonPath.parse((Object) context.read("body")).jsonString();
+        List<BodyCheck> bodyChecks = parseBodyChecks(context);
 
-        return new ExpectedRestResponseStep(httpCode, body);
+        return new ExpectedRestResponseStep(httpCode, body, bodyChecks);
     }
 
     @Override
-    public void assertResponseIsCorrect(ActualResponse response) throws JSONException {
+    @SneakyThrows
+    public void assertResponseIsCorrect(ActualResponse response) {
         JsonUtils.assertJsonEquals(body, response.body());
         Assert.assertEquals(((ActualRestResponse) response).getStatusCode(), httpCode);
+
+        if (!bodyChecks.isEmpty()) {
+            validateBodyChecks(response);
+        }
+    }
+
+    private static List<BodyCheck> parseBodyChecks(DocumentContext context) {
+        try {
+            List<Map<String, Object>> checks = context.read("bodyChecks");
+            return checks.stream()
+                    .map(checkMap -> BodyCheck.builder()
+                            .path((String) checkMap.get("path"))
+                            .type(BodyCheck.ComparisonType.valueOf((String) checkMap.get("type")))
+                            .value(checkMap.get("value"))
+                            .build())
+                    .collect(Collectors.toList());
+        } catch (PathNotFoundException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    private void validateBodyChecks(ActualResponse response) {
+        DocumentContext responseContext = JsonPath.parse(response.body());
+
+        for (BodyCheck check : bodyChecks) {
+            Object actualValue = responseContext.read(check.getPath());
+            boolean result = check.validate(actualValue);
+
+            Assert.assertTrue(
+                    String.format(
+                            "Body check failed for path '%s'. Expected %s %s but got: %s",
+                            check.getPath(),
+                            check.getType(),
+                            check.getValue(),
+                            actualValue
+                    ),
+                    result
+            );
+        }
     }
 }


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR introduces a new feature to perform checks on the response body of REST API calls, allowing for more specific validations beyond simple JSON equality.  It adds a `BodyCheck` class and integrates it into the `ExpectedRestResponseStep`.

**Key Changes**
- Added `BodyCheck` class to define checks for specific JSON paths with comparison types (currently only `GREATER_THAN`).
- Modified `ExpectedRestResponseStep` to parse and execute these body checks against the actual response.
- Updated `build.gradle` with a new version and credentials.

**Recommendations**
Ready for merge after testing various comparison types and edge cases in the `BodyCheck` logic.  Consider expanding the supported comparison types in the future.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>