### PR TITLE
revert db-call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'house.inksoftware'
-version 'java-21-0.1.8'
+version 'java-21-0.1.9'
 
 java {
     sourceCompatibility = '21'

--- a/src/main/java/house/inksoftware/systemtest/domain/steps/request/executable/db/ExecutableDatabaseRequestStep.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/steps/request/executable/db/ExecutableDatabaseRequestStep.java
@@ -25,25 +25,13 @@ public class ExecutableDatabaseRequestStep implements ExecutableRequestStep {
 
     @SneakyThrows
     private void makeDbCall() {
-        int maxAttempts = 6;
-        int attemptDelay = 500;
-        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
-            try (Connection connection = getConnection()) {
-                CallableStatement query = connection.prepareCall(this.query);
-                boolean hasResults = query.execute();
-
-                if (hasResults) {
-                    try (ResultSet resultSet = query.getResultSet()) {
-                        if (resultSet.next()) {
-                            context.put(contextVariableName.get(), resultSet.getString(1));
-                            return;
-                        }
-                    }
-                }
-                if (attempt < maxAttempts) {
-                    Thread.sleep(attemptDelay);
-                } else {
-                    throw new IllegalStateException("Expected result not found after " + maxAttempts + " attempts for query: " + query);
+        try (Connection connection = getConnection()) {
+            CallableStatement query = connection.prepareCall(this.query);
+            boolean hasResults = query.execute();
+            if (contextVariableName.isPresent() && hasResults) {
+                try (ResultSet resultSet = query.getResultSet()) {
+                    resultSet.next();
+                    context.put(contextVariableName.get(), resultSet.getString(1));
                 }
             }
         }


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR reverts a previous change related to database calls within the `ExecutableDatabaseRequestStep` class. The retry logic introduced in a prior commit has been removed.  The version number has been bumped to java-21-0.1.9.

**Key Changes**
- Removed the retry mechanism from the `makeDbCall` function, restoring the original single attempt execution.
- Updated the `makeDbCall` function to directly retrieve the first result from the result set without looping.
- Incremented the project version in `build.gradle`.

**Recommendations**
Ready to merge after verifying the intended behavior of reverting the database call logic. Ensure the removal of the retry mechanism doesn't negatively impact system stability or data retrieval.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>