### PR TITLE
adding date support in grater than

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'house.inksoftware'
-version 'java-21-0.1.7'
+version 'java-21-0.1.11'
 
 java {
     sourceCompatibility = '21'
@@ -73,7 +73,10 @@ publishing {
         mavenLocal()
         maven {
             url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-
+            credentials {
+                username = '95KontyU'
+                password = 'qT07yl78KYf69ccAtwkv0GOWkaZPz5gHAb0681Z6S999'
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -71,13 +71,6 @@ publishing {
 
     repositories {
         mavenLocal()
-        maven {
-            url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            credentials {
-                username = '95KontyU'
-                password = 'qT07yl78KYf69ccAtwkv0GOWkaZPz5gHAb0681Z6S999'
-            }
-        }
     }
 }
 

--- a/src/main/java/house/inksoftware/systemtest/domain/steps/request/executable/db/ExecutableDatabaseRequestStep.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/steps/request/executable/db/ExecutableDatabaseRequestStep.java
@@ -25,20 +25,16 @@ public class ExecutableDatabaseRequestStep implements ExecutableRequestStep {
 
     @SneakyThrows
     private void makeDbCall() {
-        try (Connection connection = getConnection()) {
-            CallableStatement query = connection.prepareCall(this.query);
-            boolean hasResults = query.execute();
+        try (Connection connection = getConnection();
+             CallableStatement query = connection.prepareCall(this.query);
+             ResultSet resultSet = query.executeQuery()) {
 
-            if (contextVariableName.isPresent() && hasResults) {
-                try (ResultSet resultSet = query.getResultSet()) {
-                    resultSet.next();
-                    context.put(contextVariableName.get(), resultSet.getString(1));
-                }
+            if (contextVariableName.isPresent() && resultSet.next()) {
+                String value = resultSet.getString(1);
+                context.put(contextVariableName.get(), value);
             }
         }
-
     }
-
     private static Connection getConnection() {
         Connection result = null;
         try {

--- a/src/main/java/house/inksoftware/systemtest/domain/steps/response/rest/BodyCheck.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/steps/response/rest/BodyCheck.java
@@ -4,7 +4,15 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Data
 @Builder
@@ -17,12 +25,17 @@ public class BodyCheck {
         return type.compare(actualValue, value);
     }
 
-
     @Getter
     public enum ComparisonType {
         GREATER_THAN("GREATER_THAN") {
             @Override
             public boolean compare(Object actual, Object expected) {
+                // Handle date comparison if expected is a date expression
+                if (expected instanceof String && ((String) expected).startsWith("now()")) {
+                    return compareDates(actual, expected, (a, b) -> a.isAfter(b));
+                }
+
+                // Fall back to number comparison
                 return compareNumbers(actual, expected, (a, b) -> a > b);
             }
         };
@@ -45,6 +58,16 @@ public class BodyCheck {
             }
         }
 
+        protected boolean compareDates(Object actual, Object expected, BiFunction<LocalDateTime, LocalDateTime, Boolean> comparison) {
+            try {
+                LocalDateTime actualDate = convertToLocalDateTime(actual);
+                LocalDateTime expectedDate = parseTimeExpression((String) expected);
+                return comparison.apply(actualDate, expectedDate);
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
         private Double convertToDouble(Object value) {
             if (value instanceof Number) {
                 return ((Number) value).doubleValue();
@@ -53,6 +76,71 @@ public class BodyCheck {
                 return Double.parseDouble((String) value);
             }
             throw new NumberFormatException("Cannot convert value to number: " + value);
+        }
+
+        private LocalDateTime convertToLocalDateTime(Object value) {
+            if (value instanceof LocalDateTime) {
+                return (LocalDateTime) value;
+            }
+            if (value instanceof ZonedDateTime) {
+                return ((ZonedDateTime) value).toLocalDateTime();
+            }
+            if (value instanceof Date) {
+                return LocalDateTime.ofInstant(((Date) value).toInstant(), java.time.ZoneId.systemDefault());
+            }
+            if (value instanceof String) {
+                try {
+                    // Try common ISO format
+                    return LocalDateTime.parse((String) value);
+                } catch (DateTimeParseException e) {
+                    // Try with formatter that handles formats like "2025-02-26T20:00:34.288782"
+                    return LocalDateTime.parse((String) value, DateTimeFormatter.ISO_DATE_TIME);
+                }
+            }
+            throw new IllegalArgumentException("Cannot convert value to LocalDateTime: " + value);
+        }
+
+        private LocalDateTime parseTimeExpression(String expression) {
+            // Pattern for expressions like "now() + 30min" or "now() - 5h"
+            Pattern pattern = Pattern.compile("now\\(\\)\\s*([+-])\\s*(\\d+)\\s*(min|hour|h|day|d|sec|s)");
+            Matcher matcher = pattern.matcher(expression.trim());
+
+            if (matcher.find()) {
+                String operation = matcher.group(1);
+                int amount = Integer.parseInt(matcher.group(2));
+                String unit = matcher.group(3);
+
+                LocalDateTime now = LocalDateTime.now();
+
+                ChronoUnit chronoUnit;
+                switch (unit.toLowerCase()) {
+                    case "min":
+                        chronoUnit = ChronoUnit.MINUTES;
+                        break;
+                    case "hour":
+                    case "h":
+                        chronoUnit = ChronoUnit.HOURS;
+                        break;
+                    case "day":
+                    case "d":
+                        chronoUnit = ChronoUnit.DAYS;
+                        break;
+                    case "sec":
+                    case "s":
+                        chronoUnit = ChronoUnit.SECONDS;
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported time unit: " + unit);
+                }
+
+                return operation.equals("+")
+                        ? now.plus(amount, chronoUnit)
+                        : now.minus(amount, chronoUnit);
+            } else if ("now()".equals(expression.trim())) {
+                return LocalDateTime.now();
+            }
+
+            throw new IllegalArgumentException("Invalid time expression: " + expression);
         }
     }
 }


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR adds support for date comparisons in the `BodyCheck` class, specifically for the `GREATER_THAN` comparison type. It introduces the ability to compare dates using expressions like `now() + 30min` and handles various date/time formats.  The version number has also been updated.

**Key Changes**
- Added date comparison logic to the `GREATER_THAN` enum in `BodyCheck.java`.
- Introduced helper functions for parsing date expressions and converting different date/time types to `LocalDateTime`.
- Updated the `build.gradle` file, bumping the version and adding credentials for Sonatype OSS deployment.

**Recommendations**
Not deployment ready. Add unit tests to verify the new date comparison logic, including edge cases and different date/time formats.  Consider removing the hardcoded credentials from the `build.gradle` file and using a more secure method for managing secrets.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>