### PR TITLE
fix: pin mockserver image to 5.15.0 to avoid :latest breakage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'house.inksoftware'
-version 'java-21-0.1.15'
+version 'java-21-0.1.17'
 
 java {
     sourceCompatibility = '21'

--- a/src/main/java/house/inksoftware/systemtest/domain/config/infra/mock/SystemTestMockedRestServerLauncher.java
+++ b/src/main/java/house/inksoftware/systemtest/domain/config/infra/mock/SystemTestMockedRestServerLauncher.java
@@ -34,7 +34,7 @@ public class SystemTestMockedRestServerLauncher implements SystemTestResourceLau
             Map<String, String> envVariables = new HashMap<>();
             envVariables.put("MOCKSERVER_INITIALIZATION_JSON_PATH", "/config/" + updatedConfigFile.getName());
 
-            container = new GenericContainer("mockserver/mockserver")
+            container = new GenericContainer("mockserver/mockserver:5.15.0")
                     .withCopyFileToContainer(MountableFile.forHostPath(updatedConfigFile.getPath()), "/config/" + updatedConfigFile.getName())
                     .withEnv(envVariables)
                     .waitingFor(Wait.forLogMessage(".*started on port:.*", 1));


### PR DESCRIPTION
## Summary

`SystemTestMockedRestServerLauncher` instantiates the mockserver Testcontainer with no tag:

```java
new GenericContainer("mockserver/mockserver")
```

Docker resolves this to `:latest`. On **2026-05-06 06:23 UTC** mockserver/mockserver:latest was republished, and the new image's startup no longer emits the `.*started on port:.*` log line within the 60s `LogMessageWaitStrategy` default. Every CI run depending on this lib (`java-21-0.1.16` and earlier) since then has been failing in `beforeTestClass` with:

```
ContainerLaunchException: Timed out waiting for log output matching '.*started on port:.*'
    at SystemTestMockedRestServerLauncher.setup(SystemTestMockedRestServerLauncher.java:43)
```

Reproduced across multiple repos and consecutive reruns on the same commit — not a flake.

## Fix

Pin the image to `mockserver/mockserver:5.15.0` (the last numbered release on Docker Hub, Jan 2023). Restores deterministic container startup; nothing else changes.

## Follow-up

Once merged, please cut a new `java-21-0.1.17` release and publish to Maven Central so consumers can bump.

## Test plan

- [ ] CI on this PR is green
- [ ] After publish, consuming repo (`integration-be`) bumps to `0.1.17` and system tests pass